### PR TITLE
fix inconsistent 'moods' pluralization in API

### DIFF
--- a/lib/client.rb
+++ b/lib/client.rb
@@ -59,6 +59,10 @@ module Jawbone
       end
     end
 
+    define_method "moods" do |*args|
+      get_helper("users/@me/mood", args.first || {})
+    end
+
     private
 
     def post_helper(path, params)


### PR DESCRIPTION
I noticed that calls to the `#moods` method failed, returning

``` ruby
{"meta"=>{"error_type"=>"endpoint_error", "message"=>"Not Found", "code"=>404, "error_detail"=>"The requested resource does not exist. Most likely you have provided an invalid xid.", "time"=>1396369429}, "data"=>{}}
```

It looks like the Jawbone API is inconsistent about pluralization when it comes to the moods endpoint. In the docs they say its accessed via

`GET https://jawbone.com/nudge/api/v.1.0/users/@me/mood`

I added a new method definition that overwrites the old one. Seems to work for me, but let me know if you have anything more elegant in mind (I hate to break the nice pattern you used)
